### PR TITLE
Create rbenv group before rbenv user

### DIFF
--- a/definitions/rbenv_installation.rb
+++ b/definitions/rbenv_installation.rb
@@ -40,13 +40,13 @@ define :rbenv_installation,
   include_recipe "git"
   include_recipe "rbenv::ruby_build"
 
+  group "rbenv" do
+    members node[:rbenv][:group_users] if node[:rbenv][:group_users]
+  end
+
   user "rbenv" do
     shell "/bin/bash"
     supports :manage_home => true
-  end
-
-  group "rbenv" do
-    members node[:rbenv][:group_users] if node[:rbenv][:group_users]
   end
 
   directory params[:rbenv_root] do


### PR DESCRIPTION
On first chef-client run during bootstrap, the user will be created,
and on many platforms will automagically have a group with the same
name created. The Ruby process chef-client is running under will not
be aware of this new group, so the call to create the group will fail.
Future runs will be fine.

By moving the group creation ahead of the user, we make sure Chef
knows about it and doesn't try to create it a second time.

See http://help.opscode.com/discussions/problems/742-group-error for
another approach, which we fortunately don't need here.
