### PR TITLE
Fix rbenv runs

### DIFF
--- a/libraries/chef_mixin_rbenv.rb
+++ b/libraries/chef_mixin_rbenv.rb
@@ -38,6 +38,7 @@ class Chef
         default_options = {
           :user => 'rbenv', 
           :group => 'rbenv', 
+          :cwd => rbenv_root,
           :env => { 
             'RBENV_ROOT' => rbenv_root
           },


### PR DESCRIPTION
- This prevents failure when chef-client is run from a folder that cannot be accessed by the rbenv user (such as /root/, which is my case...)
- I haven't tested extensively the fix
