### PR TITLE
add support for a rbenv_ruby global attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installs and manages your versions of Ruby and Gems in Chef with rbenv and ruby_
 
 ## rbenv
 
-* `rbenv[:group_users]`     - Array of users belonging to the rbenv group 
+* `rbenv[:group_users]`     - Array of users belonging to the rbenv group
 * `rbenv[:git_repository]`  - Git url of the rbenv repository to clone
 * `rbenv[:git_revision]`    - Revision of the rbenv repository to checkout
 * `rbenv[:install_prefix]`  - Path prefix rbenv will be installed into
@@ -58,7 +58,8 @@ install | Install the version of Ruby | Yes
 Attribute    | Description                                                 | Default
 -------      |-------------                                                |---------
 ruby_version | the ruby version and patch level you wish to install        | name
-force        | install even if this version is already present (reinstall) |
+force        | install even if this version is already present (reinstall) | false
+global       | set this ruby version as the global version                 | false
 
 ### Examples
 
@@ -81,7 +82,7 @@ Install specified RubyGem for the specified ruby_version managed by rbenv
 Action  | Description                           | Default
 ------- |-------------                          |---------
 install | Install the gem                       | Yes
-upgrade | Upgrade the gem to the given version  | 
+upgrade | Upgrade the gem to the given version  |
 remove  | Remove the gem                        |
 purge   | Purge the gem and configuration files |
 
@@ -132,7 +133,7 @@ rbenv_root          | path to clone rbenv into                       | '/opt/rbe
 # Releasing
 
 1. Install the prerequisite gems
-    
+
         $ gem install chef
         $ gem install thor
 

--- a/libraries/chef_mixin_rbenv.rb
+++ b/libraries/chef_mixin_rbenv.rb
@@ -36,10 +36,10 @@ class Chef
         end
 
         default_options = {
-          :user => 'rbenv', 
-          :group => 'rbenv', 
+          :user => 'rbenv',
+          :group => 'rbenv',
           :cwd => rbenv_root,
-          :env => { 
+          :env => {
             'RBENV_ROOT' => rbenv_root
           },
           :timeout => 3600
@@ -55,6 +55,16 @@ class Chef
       def ruby_version_installed?(version)
         out = rbenv_command("prefix", :env => { 'RBENV_VERSION' => version })
         out.exitstatus == 0
+      end
+
+      def rbenv_global_version?(version)
+        out = rbenv_command("global")
+        unless out.exitstatus == 0
+          raise Chef::Exceptions::ShellCommandFailed, "\n" + out.format_for_exception
+        end
+
+        global_version = out.stdout.chomp
+        global_version == version
       end
 
       def gem_binary_path_for(version)

--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -26,9 +26,9 @@ action :install do
     Chef::Log.debug "rbenv_ruby[#{@ruby.name}] is already installed so skipping"
   else
     Chef::Log.info "rbenv_ruby[#{@ruby.name}] is building, this may take a while..."
-    
+
     start_time = Time.now
-    
+
     out = rbenv_command("install #{@ruby.name}")
 
     unless out.exitstatus == 0
@@ -36,6 +36,18 @@ action :install do
     end
 
     Chef::Log.debug("rbenv_ruby[#{@ruby.name}] build time was #{(Time.now - start_time)/60.0} minutes.")
+
+    new_resource.updated_by_last_action(true)
+  end
+
+  Chef::Log.info "Ruby global? #{new_resource.global}"
+
+  if new_resource.global && !rbenv_global_version?(@ruby.name)
+    Chef::Log.info "Setting #{@ruby.name} as the rbenv global version"
+    out = rbenv_command("global #{@ruby.name}")
+    unless out.exitstatus == 0
+      raise Chef::Exceptions::ShellCommandFailed, "\n" + out.format_for_exception
+    end
     new_resource.updated_by_last_action(true)
   end
 end

--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -40,8 +40,6 @@ action :install do
     new_resource.updated_by_last_action(true)
   end
 
-  Chef::Log.info "Ruby global? #{new_resource.global}"
-
   if new_resource.global && !rbenv_global_version?(@ruby.name)
     Chef::Log.info "Setting #{@ruby.name} as the rbenv global version"
     out = rbenv_command("global #{@ruby.name}")

--- a/resources/ruby.rb
+++ b/resources/ruby.rb
@@ -23,6 +23,7 @@ actions :install
 
 attribute :ruby_version, :kind_of => String, :name_attribute => true
 attribute :force,        :default => false
+attribute :global,       :default => false
 
 def initialize(*args)
   super


### PR DESCRIPTION
I added support for a "global" attribute in the rbenv_ruby resource. This lets you specify that a Ruby version should be set as the global version in rbenv. It defaults to false.

```
rbenv_ruby "1.9.3-p194" do
  global true
end
```
