### PR TITLE
install libreadline-dev in Ubuntu & Debian so irb will work

### DIFF
--- a/definitions/rbenv_installation.rb
+++ b/definitions/rbenv_installation.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-define :rbenv_installation, 
+define :rbenv_installation,
        :type                => [:system],
        :git_repository      => 'git://github.com/sstephenson/rbenv.git',
        :git_revision        => 'master',
@@ -37,6 +37,7 @@ define :rbenv_installation,
     package "build-essential"
     package "openssl"
     package "libssl-dev"
+    package "libreadline-dev"
   end
 
   include_recipe "git"


### PR DESCRIPTION
IRB needs libreadline-dev installed when a Ruby is compiled for it to work. So I added it to the packages that get installed on Ubuntu and Debian.

I don't know if RedHat-style distros need this or not, I've only tested on Ubuntu 11.10.
