### PR TITLE
Openssl on RHEL5.8

### DIFF
--- a/definitions/rbenv_installation.rb
+++ b/definitions/rbenv_installation.rb
@@ -33,6 +33,8 @@ define :rbenv_installation,
   package "curl"
 
   case node[:platform]
+  when "redhat"
+    package "openssl-devel"
   when "ubuntu", "debian"
     package "build-essential"
     package "openssl"


### PR DESCRIPTION
We ran into a build of RHEL 5.8 that didn't have openssl-devel installed by default. Throwing this in corrected the problem.
