### PR TITLE
relaxing version constraint for ohai

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -17,4 +17,4 @@ end
   depends cb
 end
 
-depends 'ohai', '~> 1.0.2'
+depends 'ohai', '>= 1.1.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,4 +17,4 @@ end
   depends cb
 end
 
-depends 'ohai', '>= 1.1.0'
+depends 'ohai', '~> 1.0'


### PR DESCRIPTION
The version contraint for ohai is too restrictive. The nginx cookbook just relaxed the constraint as well.

Is there any reason that the version for ohai needs to be between 1.1.2 and 1.2.0?
