### PR TITLE
refactor repetition of rbenv_root and rbenv_binary_path

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,8 +19,8 @@
 # limitations under the License.
 #
 
-node.set[:rbenv][:root]          = "#{node[:rbenv][:install_prefix]}/rbenv"
-node.set[:ruby_build][:bin_path] = "#{node[:ruby_build][:prefix]}/bin"
+node.set[:rbenv][:root]          = rbenv_root
+node.set[:ruby_build][:bin_path] = rbenv_binary_path
 
 package "curl"
 


### PR DESCRIPTION
use the library functions rbenv_root and rbenv_binary_path defined by chef_mixin_rbenv
