### PR TITLE
make sure shims and versions sub-directory is owned by rbenv user.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -83,3 +83,15 @@ ruby_block "initialize_rbenv" do
 
   action :nothing
 end
+
+# rbenv init creates these directories as root because it is called
+# from /etc/profile.d/rbenv.sh But we want them to be owned by rbenv
+# check https://github.com/sstephenson/rbenv/blob/master/libexec/rbenv-init#L71
+%w{shims versions}.each do |dir_name|
+  directory "#{node[:rbenv][:root]}/#{dir_name}" do
+    owner "rbenv"
+    group "rbenv"
+    mode "0775"
+    action [:create]
+  end
+end


### PR DESCRIPTION
it is created by rbenv via a startup script so is owned by root
we create some sub-folders owned by rbenv before the init script runs
