### PR TITLE
add recipe to install rbenv-vars plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ To install rbenv and ruby_build; Include each recipe in one of your cookbook's r
     include_recipe "rbenv::default"
     include_recipe "rbenv::ruby_build"
 
+## Installing rbenv-vars
+
+To install rbenv-vars; Include this recipe in one of your cookbook's recipes
+
+    include_recipe "rbenv::rbenv_vars"
+
 ## Installing a Ruby
 
 And now to install a Ruby use the `rbenv_ruby` LWRP

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,7 @@ version          "1.4.1"
 recipe "rbenv", "Installs and configures rbenv"
 recipe "rbenv::ruby_build", "Installs and configures ruby_build"
 recipe "rbenv::ohai_plugin", "Installs an rbenv Ohai plugin to populate automatic_attrs about rbenv and ruby_build"
+recipe "rbenv::rbenv_vars", "Installs an rbenv plugin rbenv-vars that lets you set global and project-specific environment variables before spawning Ruby processes"
 
 %w{ centos redhat fedora ubuntu debian }.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -87,7 +87,7 @@ end
 # rbenv init creates these directories as root because it is called
 # from /etc/profile.d/rbenv.sh But we want them to be owned by rbenv
 # check https://github.com/sstephenson/rbenv/blob/master/libexec/rbenv-init#L71
-%w{shims versions}.each do |dir_name|
+%w{shims versions plugins}.each do |dir_name|
   directory "#{node[:rbenv][:root]}/#{dir_name}" do
     owner "rbenv"
     group "rbenv"

--- a/recipes/rbenv_vars.rb
+++ b/recipes/rbenv_vars.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: rbenv
 # Recipe:: rbenv_vars
 #
-# Author:: Jamie Winsor (<jamie@vialstudios.com>)
+# Author:: Deepak Kannan (<kannan.deepak@gmail.com>)
 #
 # Copyright 2011-2012, Riot Games
 #

--- a/recipes/rbenv_vars.rb
+++ b/recipes/rbenv_vars.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: rbenv
-# Attributes:: default
+# Recipe:: rbenv_vars
 #
 # Author:: Jamie Winsor (<jamie@vialstudios.com>)
 #
@@ -19,14 +19,12 @@
 # limitations under the License.
 #
 
-default[:rbenv][:group_users]         = Array.new
-default[:rbenv][:git_repository]      = "git://github.com/sstephenson/rbenv.git"
-default[:rbenv][:git_revision]        = "master"
-default[:rbenv][:install_prefix]      = "/opt"
+include_recipe "git"
 
-default[:ruby_build][:git_repository] = "git://github.com/sstephenson/ruby-build.git"
-default[:ruby_build][:git_revision]   = "master"
-default[:ruby_build][:prefix]         = "/usr/local"
+plugin_path = "#{node[:rbenv][:root]}/plugins/rbenv-vars"
 
-default[:rbenv_vars][:git_repository] = "git://github.com/sstephenson/rbenv-vars.git"
-default[:rbenv_vars][:git_revision]   = "master"
+git plugin_path do
+  repository node[:rbenv_vars][:git_repository]
+  reference  node[:rbenv_vars][:git_revision]
+  action :sync
+end


### PR DESCRIPTION
Add recipe to install rbenv-vars plugin.  

https://github.com/sstephenson/rbenv-vars

> This is a plugin for rbenv that lets you set global and project-specific environment variables
> before spawning Ruby processes.
