### PR TITLE
install ruby-build on top of rbenv

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,6 @@ default[:rbenv][:install_prefix]      = "/opt"
 
 default[:ruby_build][:git_repository] = "git://github.com/sstephenson/ruby-build.git"
 default[:ruby_build][:git_revision]   = "master"
-default[:ruby_build][:prefix]         = "/usr/local"
 
 default[:rbenv_vars][:git_repository] = "git://github.com/sstephenson/rbenv-vars.git"
 default[:rbenv_vars][:git_revision]   = "master"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,7 @@
 #
 
 node.set[:rbenv][:root]          = rbenv_root
+node.set[:ruby_build][:prefix]   = node[:rbenv][:root]
 node.set[:ruby_build][:bin_path] = rbenv_binary_path
 
 include_recipe "rbenv::package_requirements"


### PR DESCRIPTION
rbenv user and groups is used in four places
- in libraries/chef_mixin_rbenv.rb#L39 to run rbenv commands
- in libraries/provider_rbenv_rubygems.rb#L68 to install gems
- in recipes/default.rb#L46 to install rbenv
- in providers/ruby.rb#L32 to install rubies via 'rbenv install'

for this reason ruby-build is also installed by the rbenv user and group
like installing rbenv
