### PR TITLE
Add feature to install rbenv and ruby-build from tarball

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,8 +24,28 @@ default[:rbenv][:git_repository]      = "git://github.com/sstephenson/rbenv.git"
 default[:rbenv][:git_revision]        = "master"
 default[:rbenv][:install_prefix]      = "/opt"
 
+# This can be `git` or `file`. If git, rbenv is installed from GitHub 
+# like a standard install. If `file`, it is installed by using a file
+# from the cookbook. See node[:rbenv][:filename] below
+default[:rbenv][:install_method] = "git"
+
+# Path to rbenv tar.gz file. Assumed to have an name in the form
+# `rbenv-version.tar.gz` which contains a directory
+# `rbenv-master`. This is based on what you get when you download
+# the master branch as a tarball from GitHub
+default[:rbenv][:filename]       = nil
+default[:rbenv][:cookbook]       = nil
+
 default[:ruby_build][:git_repository] = "git://github.com/sstephenson/ruby-build.git"
 default[:ruby_build][:git_revision]   = "master"
+
+# See node[:rbenv][:install_method] above
+default[:ruby_build][:install_method] = "git"
+# Path to ruby-build tar.gz file. Assumed to have an name in the form
+# `ruby-build-version.tar.gz` which contains a directory
+# `ruby-build-version`.
+default[:ruby_build][:filename]       = nil
+default[:ruby_build][:cookbook]       = nil
 
 default[:rbenv_vars][:git_repository] = "git://github.com/sstephenson/rbenv-vars.git"
 default[:rbenv_vars][:git_revision]   = "master"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -56,11 +56,6 @@ when "file"
   cache_path = File.join(node[:rbenv][:root], "cache")
   node.set[:rbenv][:cache_path] = cache_path
 
-  directory cache_path do
-    owner "rbenv"
-    group "rbenv"
-    mode 0755
-  end
 
   cookbook_file node[:rbenv][:filename] do
     owner "rbenv"
@@ -84,6 +79,13 @@ when "file"
     not_if {
       File.exists?(node[:rbenv][:root]) && node[:rbenv][:installed_version] == rbenv_version
     }
+    notifies :create, "template[/etc/profile.d/rbenv.sh]", :immediately
+  end
+
+  directory cache_path do
+    owner "rbenv"
+    group "rbenv"
+    mode 0755
   end
 
   directory node[:rbenv][:root] do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -82,7 +82,7 @@ when "file"
     EOH
     notifies :create, "directory[#{node[:rbenv][:root]}]", :immediately
     not_if {
-      node[:rbenv][:installed_version] == rbenv_version
+      File.exists?(node[:rbenv][:root]) && node[:rbenv][:installed_version] == rbenv_version
     }
   end
 


### PR DESCRIPTION
Hi

I've added the possibility to install rbenv and ruby-build from a tarball instead of git, since I'm deploying stuff on machines without internet access. Would you be interested in this? In this version I actually include the tarballs in the cookbook, which might be a bad idea, I'm going to look into changing it so it can be set up from a "wrapper" cookbook instead. 

If you're interested in this functionality, I'll clean it up a bit and update this PR, otherwise I'll just hack it to work for me. So I wouldn't really recommend merging this in it's current shape.
