### PR TITLE
gem install functionality fix

### DIFF
--- a/libraries/provider_rbenv_rubygems.rb
+++ b/libraries/provider_rbenv_rubygems.rb
@@ -63,8 +63,9 @@ class Chef
 
         def install_via_gem_command(name, version)
           src = @new_resource.source && "  --source=#{@new_resource.source} --source=http://rubygems.org"
+          version_option = ( version.empty?() ? "" : " -v \"#{version}\"" )
           shell_out!(
-            "#{gem_binary_path} install #{name} -q --no-rdoc --no-ri -v \"#{version}\"#{src}#{opts}", 
+            "#{gem_binary_path} install #{name} -q --no-rdoc --no-ri #{version_option} #{src}#{opts}", 
             :user => 'rbenv',
             :group => 'rbenv',
             :env => {


### PR DESCRIPTION
`gem install` commands don't support blank strings for the -v option. I've  
included below the error output I received from invoking this to install
a gem, and how it failed since it included '-v ""' in the install command.  This patch
will ensure that the -v option is stripped out, unless a version is explicitly set.
-N

Using this provider as follows:
  rbenv_gem "bundler" do
    ruby_version "1.9.3-p194"
  end

Yielded the following install command:
Expected process to exit with [0], but received '1'
---- Begin output of /opt/rbenv/versions/1.9.3-p194/bin/gem install bundler -q --no-rdoc --no-ri -v "" ----
STDOUT:
STDERR: ERROR:  While executing gem ... (ArgumentError)
    Illformed requirement [""]
---- End output of /opt/rbenv/versions/1.9.3-p194/bin/gem install bundler -q --no-rdoc --no-ri -v "" ----
Ran /opt/rbenv/versions/1.9.3-p194/bin/gem install bundler -q --no-rdoc --no-ri -v "" returned 1
