### PR TITLE
Avoid duplicated /bin/bin for ruby-build path

### DIFF
--- a/templates/default/rbenv.sh.erb
+++ b/templates/default/rbenv.sh.erb
@@ -1,4 +1,4 @@
 export RBENV_ROOT=<%= @rbenv_root %>
-export PATH=$RBENV_ROOT/bin:<%= @ruby_build_bin_path %>/bin:$PATH
+export PATH=$RBENV_ROOT/bin:<%= @ruby_build_bin_path %>:$PATH
 source $RBENV_ROOT/completions/rbenv.bash
 eval "$(rbenv init -)"


### PR DESCRIPTION
ruby_build_bin_path already includes '/bin' as part of it, so
rbenv.sh.erb do not require it again.

This avoid having a non-existing directory in the PATH lookup.

This fixes Issue #32
