### PR TITLE
Introduced support for zsh on completions scripts

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,9 +19,10 @@
 # limitations under the License.
 #
 
-default[:rbenv][:user]          = "rbenv"
-default[:rbenv][:group]         = "rbenv"
-default[:rbenv][:manage_home]   = true
+default[:rbenv][:user]            = "rbenv"
+default[:rbenv][:group]           = "rbenv"
+default[:rbenv][:manage_home]     = true
+default[:rbenv][:completions_ext] = "bash"
 
 default[:rbenv][:group_users]         = Array.new
 default[:rbenv][:git_repository]      = "git://github.com/sstephenson/rbenv.git"

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       "Riot Games"
 maintainer_email "jamie@vialstudios.com"
 license          "Apache 2.0"
 description      "Installs and configures rbenv"
-version          "1.4.2"
+version          "1.4.3"
 
 recipe "rbenv", "Installs and configures rbenv"
 recipe "rbenv::ruby_build", "Installs and configures ruby_build"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -56,7 +56,8 @@ template "/etc/profile.d/rbenv.sh" do
   mode "0644"
   variables(
     :rbenv_root => node[:rbenv][:root],
-    :ruby_build_bin_path => node[:ruby_build][:bin_path]
+    :ruby_build_bin_path => node[:ruby_build][:bin_path],
+    :rbenv_completions_ext => node[:rbenv][:completions_ext]
   )
 
   notifies :create, "ruby_block[initialize_rbenv]", :immediately

--- a/templates/default/rbenv.sh.erb
+++ b/templates/default/rbenv.sh.erb
@@ -1,4 +1,4 @@
 export RBENV_ROOT=<%= @rbenv_root %>
 export PATH=$RBENV_ROOT/bin:<%= @ruby_build_bin_path %>:$PATH
-source $RBENV_ROOT/completions/rbenv.bash
+source $RBENV_ROOT/completions/rbenv.<%= @rbenv_completions_ext %>
 eval "$(rbenv init -)"


### PR DESCRIPTION
@sstephenson changed rbenv to support zsh (zsh does not support the complete command). It was added around commit [f635c8715cd990fa6f066117c67240ac38ef9b46](https://github.com/sstephenson/rbenv/commit/f635c8715cd990fa6f066117c67240ac38ef9b46#completions/rbenv.zsh).

This PR adds the same support to the cookbook, otherwise you'll get a error message when loggin onto the machine.

`/opt/rbenv/completions/rbenv.bash:16: command not found: complete`
