### PR TITLE
use default attributes for user:group

### DIFF
--- a/libraries/provider_rbenv_rubygems.rb
+++ b/libraries/provider_rbenv_rubygems.rb
@@ -67,8 +67,8 @@ class Chef
 
           shell_out!(
             "#{gem_binary_path} install #{name} -q --no-rdoc --no-ri #{version_option} #{src}#{opts}",
-            :user => 'rbenv',
-            :group => 'rbenv',
+            :user => node[:rbenv][:user],
+            :group => node[:rbenv][:group],
             :env => {
               'RBENV_VERSION' => @new_resource.ruby_version
             }


### PR DESCRIPTION
this file should be using the default attributes for user:group like other sections instead of hardcoding for rbenv:rbenv.
