### PR TITLE
Fix ruby_build_installed_verison typo.

### DIFF
--- a/libraries/chef_mixin_ruby_build.rb
+++ b/libraries/chef_mixin_ruby_build.rb
@@ -28,7 +28,7 @@ class Chef
         "#{node[:ruby_build][:prefix]}/bin/ruby-build"
       end
 
-      def ruby_build_installed_verison
+      def ruby_build_installed_version
         out = shell_out("#{ruby_build_binary_path} --version", :env => nil)
         out.stdout.chomp
       end

--- a/libraries/resource_ext.rb
+++ b/libraries/resource_ext.rb
@@ -40,7 +40,7 @@ class Chef
 
       def desired_ruby_build_version?
         if File.exists?("#{ruby_build_binary_path}")
-          ruby_build_installed_verison.match(/#{node[:ruby_build][:version]}$/).nil? ? false : true
+          ruby_build_installed_version.match(/#{node[:ruby_build][:version]}$/).nil? ? false : true
         else
           false
         end


### PR DESCRIPTION
I renamed `ruby_build_installed_verison` to `ruby_build_installed_version` in both the definition and usage.

This method is defined as public, but it looks like it's only public usage (based on a [Google search](https://www.google.com/search?q="ruby_build_installed_verison"&filter=0)) is in this recipe (and copies thereof). However, I would be happy to include a deprecated `ruby_build_installed_verison` method if you think it necessary.
