### PR TITLE
Fix incorrect node[:ruby_build][:prefix] and node[:ruby_build][:bin_path]

### DIFF
--- a/libraries/chef_mixin_ruby_build.rb
+++ b/libraries/chef_mixin_ruby_build.rb
@@ -25,7 +25,7 @@ class Chef
   module Mixin
     module RubyBuild
       def ruby_build_binary_path
-        "#{node[:ruby_build][:prefix]}/bin/ruby-build"
+        "#{node[:ruby_build][:bin_path]}/ruby-build"
       end
 
       def ruby_build_installed_version

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,8 +20,8 @@
 #
 
 node.set[:rbenv][:root]          = rbenv_root
-node.set[:ruby_build][:prefix]   = node[:rbenv][:root]
-node.set[:ruby_build][:bin_path] = rbenv_binary_path
+node.set[:ruby_build][:prefix]   = "#{node[:rbenv][:root]}/plugins/ruby_build"
+node.set[:ruby_build][:bin_path] = "#{node[:ruby_build][:prefix]}/bin"
 
 case node[:platform]
 when "ubuntu", "debian"

--- a/recipes/ruby_build.rb
+++ b/recipes/ruby_build.rb
@@ -21,9 +21,7 @@
 
 include_recipe "git"
 
-plugin_path = "#{node[:rbenv][:root]}/plugins/ruby_build"
-
-git plugin_path do
+git node[:ruby_build][:prefix] do
   repository node[:ruby_build][:git_repository]
   reference node[:ruby_build][:git_revision]
   action :sync


### PR DESCRIPTION
Currently `node[:ruby_build][:prefix]` and `node[:ruby_build][:bin_path]` gives us wrong paths, which are `/opt/rbenv` and `/opt/rbenv/bin/rbenv` respectively. As a consequence, the genrated `/etc/profile.d/rbenv.sh` contains a wrong PATH value as following:

``` sh
export PATH=$RBENV_ROOT/bin:/opt/rbenv/bin/rbenv:$PATH
```

where there exists `/opt/rbenv/bin/rbenv` instead of `/opt/rbenv/plugins/ruby_build/bin`. With this patch, the attribues would be fixed to `/opt/rbenv/plugins/ruby_build` and `/opt/rbenv/plugins/ruby_build/bin` as we expected.

I haven't managed to run the vagrant tests becase I got this error:

```
undefined local variable or method `use_inline_resources' for #<Class:0x0000000238b268>
```

but I've checked it in a in-house wrapper cookbook instead.
