### PR TITLE
Add shims to PATH. Fixes #36

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -112,7 +112,7 @@ end
 ruby_block "initialize_rbenv" do
   block do
     ENV['RBENV_ROOT'] = node[:rbenv][:root]
-    ENV['PATH'] = "#{node[:rbenv][:root]}/bin:#{node[:ruby_build][:bin_path]}:#{ENV['PATH']}"
+    ENV['PATH'] = "#{node[:rbenv][:root]}/bin:#{node[:rbenv][:root]}/shims:#{node[:ruby_build][:bin_path]}:#{ENV['PATH']}"
   end
 
   action :nothing


### PR DESCRIPTION
This is required to put jruby in the path so that gem can install correctly.
