### PR TITLE
Mode changes facilitating group gem/bundle install, fixes #52

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -40,6 +40,15 @@ action :install do
     new_resource.updated_by_last_action(true)
   end
 
+  chmod_options = {
+    :user => node[:rbenv][:user],
+    :group => node[:rbenv][:group],
+    :cwd => rbenv_root
+  }
+  unless Chef::Platform.windows?
+    shell_out("chmod -R 2775 versions/#{new_resource.name}", chmod_options)
+  end
+
   if new_resource.global && !rbenv_global_version?(new_resource.name)
     Chef::Log.info "Setting #{new_resource.name} as the rbenv global version"
     out = rbenv_command("global #{new_resource.name}")

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -85,7 +85,7 @@ end
 directory node[:rbenv][:root] do
   owner node[:rbenv][:user]
   group node[:rbenv][:group]
-  mode "0775"
+  mode "2775"
 end
 
 git node[:rbenv][:root] do
@@ -125,7 +125,7 @@ end
   directory "#{node[:rbenv][:root]}/#{dir_name}" do
     owner node[:rbenv][:user]
     group node[:rbenv][:group]
-    mode "0775"
+    mode "2775"
     action [:create]
   end
 end


### PR DESCRIPTION
Perform an explicit chmod on each installed version on create to ensure
that all users in node[:rbenv][:group] can use gem/bundle install without
permission errors.

Change to using setgid bits so that gems and shims installed by users
with different default group can still be uninstalled by other users/chef

One could argue that all gem management should go through chef, but I
think it is an appropriate expediant to allow members of the group to
run bundle install for new apps without error. (though ideally some
warning might be possible)
