### PR TITLE
Installed rubies (inside of node[:rbenv][:root]/versions) end up moded 0755

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -37,6 +37,16 @@ action :install do
 
     Chef::Log.debug("rbenv_ruby[#{new_resource.name}] build time was #{(Time.now - start_time)/60.0} minutes.")
 
+    chmod_options = {
+      :user => node[:rbenv][:user],
+      :group => node[:rbenv][:group],
+      :cwd => rbenv_root_path
+    }
+    unless Chef::Platform.windows?
+      shell_out("chmod -R 0775 versions/#{new_resource.name}", chmod_options)
+      shell_out("find versions/#{new_resource.name} -type d -exec chmod +s {} \\;", chmod_options)
+    end
+
     new_resource.updated_by_last_action(true)
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -88,7 +88,7 @@ end
 directory node[:rbenv][:root] do
   owner node[:rbenv][:user]
   group node[:rbenv][:group]
-  mode "0775"
+  mode "2775"
   recursive true
 end
 
@@ -133,7 +133,7 @@ end
   directory "#{node[:rbenv][:root]}/#{dir_name}" do
     owner node[:rbenv][:user]
     group node[:rbenv][:group]
-    mode "0775"
+    mode "2775"
     action [:create]
   end
 end


### PR DESCRIPTION
Despite the essential chmod on versions at the end of the default recipe, the subdirectory containing the actual installed version is not accessible to members of node[:rbenv][:group] other than node[:rbenv][:user]

I tried making

``` ruby
    out = rbenv_command("install #{new_resource.name}")
```

in providers/ruby.rb into 

``` ruby
    out = rbenv_command("install #{new_resource.name}", :umask =>'002')
```

to no avail. (I verified the umask was making it all the way to Mixlib::ShellOut::Unix#run_command, but the generated dir was still 755. So maybe call that a bug in sstephenson/ruby-build or the ruby Makefiles or something )

Adding a `recursive true` to the resource in the end of the default recipe also proved ineffective -- digging, this makes sense as all the ACL handling for directory resources is imported whole-cloth from files with no concept of recursion. :-(

Sooooo ... seems like the only option for the present, without requiring upstream changes to either chef or ruby-build is to add an explicit chmod on the directory after the install.
