### PR TITLE
ensure rbenv is initialized before executing commands

### DIFF
--- a/providers/execute.rb
+++ b/providers/execute.rb
@@ -18,6 +18,8 @@ def load_current_resource
 end
 
 action :run do
+  execute "eval \"$(rbenv init -)\""
+
   exec_resource = execute new_resource.name do
     command     new_resource.command
     creates     new_resource.creates


### PR DESCRIPTION
This is when chef-client is run and /etc/profile.d/rbenv.sh hasn't been sourced before the rbenv_execute block has been hit
