### PR TITLE
ohai_plugin broken, 31c1ad9c6 removed rbenv_binary_path but recipe still uses

### DIFF
--- a/recipes/ohai_plugin.rb
+++ b/recipes/ohai_plugin.rb
@@ -21,7 +21,7 @@
 
 include_recipe "ohai"
 
-bin_path = rbenv_binary_path
+bin_path = rbenv_bin_path
 template "#{node[:ohai][:plugin_path]}/rbenv.rb" do
   source 'plugins/rbenv.rb.erb'
   owner 'root'

--- a/recipes/ohai_plugin.rb
+++ b/recipes/ohai_plugin.rb
@@ -21,7 +21,8 @@
 
 include_recipe "ohai"
 
-bin_path = rbenv_bin_path
+bin_path = ::File.join(rbenv_bin_path, "rbenv")
+
 template "#{node[:ohai][:plugin_path]}/rbenv.rb" do
   source 'plugins/rbenv.rb.erb'
   owner 'root'


### PR DESCRIPTION
see 31c1ad9c6ed2dbbf80bebf02d11b903932c5425a

and 

https://github.com/RiotGames/rbenv-cookbook/blob/master/recipes/ohai_plugin.rb#L24
