### PR TITLE
Change syntax for 1.8.7 compatibility.

### DIFF
--- a/libraries/provider_rbenv_rubygems.rb
+++ b/libraries/provider_rbenv_rubygems.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-require_relative 'chef_mixin_rbenv'
+require File.join(File.dirname(__FILE__), 'chef_mixin_rbenv')
 
 class Chef
   class Provider
@@ -43,12 +43,12 @@ class Chef
 
           def shell_out!(*args)
             options = args.last.is_a?(Hash) ? args.pop : Hash.new
-            options.merge!(env: {
+            options.merge!(:env => {
               "RBENV_ROOT"    => rbenv_root_path,
               "RBENV_VERSION" => ruby_version,
               "PATH"          => ([ rbenv_shims_path, rbenv_bin_path ] + system_path).join(':')
             })
-            original_shell_out!(*args, options)
+            original_shell_out!(*args.push(options))
           end
 
           private

--- a/resources/execute.rb
+++ b/resources/execute.rb
@@ -8,14 +8,14 @@
 actions :run
 default_action :run
 
-attribute :command, kind_of: [String, Array], name_attribute: true
-attribute :creates, kind_of: String
-attribute :cwd, kind_of: String
-attribute :environment, kind_of: Hash, default: Hash.new
-attribute :group, kind_of: [String, Integer]
-attribute :path, kind_of: Array, default: Array.new
-attribute :returns, kind_of: [Integer, Array]
-attribute :timeout, kind_of: Integer
-attribute :umask, kind_of: [String, Integer]
-attribute :user, kind_of: [String, Integer]
-attribute :ruby_version, kind_of: String
+attribute :command, :kind_of => [String, Array], :name_attribute => true
+attribute :creates, :kind_of => String
+attribute :cwd, :kind_of => String
+attribute :environment, :kind_of => Hash, :default => Hash.new
+attribute :group, :kind_of => [String, Integer]
+attribute :path, :kind_of => Array, :default => Array.new
+attribute :returns, :kind_of => [Integer, Array]
+attribute :timeout, :kind_of => Integer
+attribute :umask, :kind_of => [String, Integer]
+attribute :user, :kind_of => [String, Integer]
+attribute :ruby_version, :kind_of => String


### PR DESCRIPTION
Ruby 1.8 is still the default on many servers that run chef so I think it makes sense to continue supporting it. Changes include reverting to hash rocket syntax for key-value pairs, replacing require_relative with require, and merging arguments into a single array when using the splat operator.
