### PR TITLE
Umask option fix

### DIFF
--- a/providers/execute.rb
+++ b/providers/execute.rb
@@ -31,7 +31,7 @@ action :run do
     returns     new_resource.returns
     timeout     new_resource.timeout
     user        new_resource.user
-    umask       new_resource.user
+    umask       new_resource.umask
   end
 
   new_resource.updated_by_last_action(true)


### PR DESCRIPTION
Option `umask` for resource `rbenv_execute` was unable to set due to typo. Trivial fix.
