### PR TITLE
Added Ruby 1.9 to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Installs and manages your versions of Ruby and Gems in Chef with rbenv and ruby_
 
 * Chef 10
 * Centos / Redhat / Fedora / Ubuntu / Debian
+* Ruby >= 1.9
 
 # Usage
 


### PR DESCRIPTION
This project will not run if ruby 1.8.7 is used to install it. (Ruby 1.8.7 does not understand the new hash syntax of {this: 'is a string'}
