### PR TITLE
Ensure $HOME is set to `node[:rbenv][:user]` before git clones

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,23 @@
+---
+driver_plugin: vagrant
+driver_config:
+  require_chef_omnibus: true
+
+platforms:
+- name: debian-7.1.0
+- name: debian-6
+  driver_config:
+    box: opscode-debian-6.0.7
+    box_url: http://opscode-vm.s3.amazonaws.com/vagrant/opscode_debian-6.0.7_chef-11.2.0.box
+- name: ubuntu-13.04
+- name: ubuntu-12.04
+- name: ubuntu-10.04
+- name: centos-6.4
+- name: centos-5.9
+suites:
+- name: ruby_install
+  run_list:
+  - recipe[fake::ruby_install]
+- name: gem_install
+  run_list:
+  - recipe[fake::gem_install]

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,7 @@
 site :opscode
 
 metadata
+
+group :test do
+  cookbook 'fake', :path => 'test/fixtures/cookbooks/fake'
+end

--- a/libraries/chef_mixin_rbenv.rb
+++ b/libraries/chef_mixin_rbenv.rb
@@ -92,6 +92,42 @@ class Chef
       def rbenv_root_path
         "#{node[:rbenv][:install_prefix]}/rbenv"
       end
+
+      # Ensures $HOME is temporarily set to the given user. The original
+      # $HOME is preserved and re-set after the block has been yielded
+      # to.
+      #
+      # This is a workaround for CHEF-3940. TL;DR Certain versions of
+      # `git` misbehave if configuration is inaccessible in $HOME.
+      #
+      # More info here:
+      #
+      #   https://github.com/git/git/commit/4698c8feb1bb56497215e0c10003dd046df352fa
+      #
+      def with_home_for_user(username, &block)
+
+        time = Time.now.to_i
+
+        ruby_block "set HOME for #{username} at #{time}" do
+          block do
+            ENV['OLD_HOME'] = ENV['HOME']
+            ENV['HOME'] = begin
+              require 'etc'
+              Etc.getpwnam(username).dir
+            rescue ArgumentError # user not found
+              "/home/#{username}"
+            end
+          end
+        end
+
+        yield
+
+        ruby_block "unset HOME for #{username} #{time}" do
+          block do
+            ENV['HOME'] = ENV['OLD_HOME']
+          end
+        end
+      end
     end
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -88,14 +88,18 @@ directory node[:rbenv][:root] do
   mode "0775"
 end
 
-git node[:rbenv][:root] do
-  repository node[:rbenv][:git_repository]
-  reference node[:rbenv][:git_revision]
-  user node[:rbenv][:user]
-  group node[:rbenv][:group]
-  action :sync
+with_home_for_user(node[:rbenv][:user]) do
 
-  notifies :create, "template[/etc/profile.d/rbenv.sh]", :immediately
+  git node[:rbenv][:root] do
+    repository node[:rbenv][:git_repository]
+    reference node[:rbenv][:git_revision]
+    user node[:rbenv][:user]
+    group node[:rbenv][:group]
+    action :sync
+
+    notifies :create, "template[/etc/profile.d/rbenv.sh]", :immediately
+  end
+
 end
 
 template "/etc/profile.d/rbenv.sh" do

--- a/recipes/rbenv_vars.rb
+++ b/recipes/rbenv_vars.rb
@@ -23,10 +23,14 @@ include_recipe "git"
 
 plugin_path = "#{node[:rbenv][:root]}/plugins/rbenv-vars"
 
-git plugin_path do
-  repository node[:rbenv_vars][:git_repository]
-  reference  node[:rbenv_vars][:git_revision]
-  action :sync
-  user node[:rbenv][:user]
-  group node[:rbenv][:group]
+with_home_for_user(node[:rbenv][:user]) do
+
+  git plugin_path do
+    repository node[:rbenv_vars][:git_repository]
+    reference  node[:rbenv_vars][:git_revision]
+    action :sync
+    user node[:rbenv][:user]
+    group node[:rbenv][:group]
+  end
+
 end

--- a/recipes/ruby_build.rb
+++ b/recipes/ruby_build.rb
@@ -21,10 +21,14 @@
 
 include_recipe "git"
 
-git node[:ruby_build][:prefix] do
-  repository node[:ruby_build][:git_repository]
-  reference node[:ruby_build][:git_revision]
-  action :sync
-  user node[:rbenv][:user]
-  group node[:rbenv][:group]
+with_home_for_user(node[:rbenv][:user]) do
+
+  git node[:ruby_build][:prefix] do
+    repository node[:ruby_build][:git_repository]
+    reference node[:ruby_build][:git_revision]
+    action :sync
+    user node[:rbenv][:user]
+    group node[:rbenv][:group]
+  end
+
 end

--- a/test/fixtures/cookbooks/fake/attributes/default.rb
+++ b/test/fixtures/cookbooks/fake/attributes/default.rb
@@ -1,0 +1,2 @@
+
+default['fake']['ruby_version'] = '1.9.3-p448'

--- a/test/fixtures/cookbooks/fake/metadata.rb
+++ b/test/fixtures/cookbooks/fake/metadata.rb
@@ -1,0 +1,4 @@
+name    'fake'
+version '1.0.0'
+
+depends 'rbenv'

--- a/test/fixtures/cookbooks/fake/recipes/gem_install.rb
+++ b/test/fixtures/cookbooks/fake/recipes/gem_install.rb
@@ -1,0 +1,6 @@
+include_recipe 'fake::ruby_install'
+
+rbenv_gem 'bundler' do
+  ruby_version node['fake']['ruby_version']
+  version '1.3.5'
+end

--- a/test/fixtures/cookbooks/fake/recipes/ruby_install.rb
+++ b/test/fixtures/cookbooks/fake/recipes/ruby_install.rb
@@ -1,0 +1,7 @@
+
+include_recipe 'rbenv::default'
+include_recipe 'rbenv::ruby_build'
+
+rbenv_ruby node['fake']['ruby_version'] do
+  global true
+end

--- a/test/integration/gem_install/bats/gem_install.bats
+++ b/test/integration/gem_install/bats/gem_install.bats
@@ -1,0 +1,6 @@
+@test "installs a gem into the correct Ruby" {
+  # We have unset these vars to bust out of Busser's sandbox
+  unset GEM_HOME GEM_PATH GEM_CACHE
+  run /opt/rbenv/shims/gem list bundler -v 1.3.5 -i
+  [ "$status" -eq 0 ]
+}

--- a/test/integration/ruby_install/bats/ruby_install.bats
+++ b/test/integration/ruby_install/bats/ruby_install.bats
@@ -1,0 +1,8 @@
+@test "installs the correct version of Ruby" {
+  /opt/rbenv/shims/ruby --version | grep 1.9.3p448
+}
+
+@test "properly sets PATH environment variable" {
+  . /etc/profile.d/rbenv.sh
+  ruby --version | grep 1.9.3p448
+}


### PR DESCRIPTION
This is a workaround for CHEF-3940. TL;DR Certain versions of `git` misbehave if configuration is inaccessible in $HOME. We work around this issue by ensuring $HOME is temporarily set to the `node[:rbenv][:user]` user before performing a `git` operation.

This PR also adds Test Kitchen support and some initial Bats integration tests.
