### PR TITLE
Use HTTPS instead of Git protocol for clones.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,13 +23,13 @@ default[:rbenv][:user]           = "rbenv"
 default[:rbenv][:group]          = "rbenv"
 default[:rbenv][:manage_home]    = true
 default[:rbenv][:group_users]    = Array.new
-default[:rbenv][:git_repository] = "git://github.com/sstephenson/rbenv.git"
+default[:rbenv][:git_repository] = "https://github.com/sstephenson/rbenv.git"
 default[:rbenv][:git_revision]   = "master"
 default[:rbenv][:install_prefix] = "/opt"
 default[:rbenv][:root_path]      = "#{node[:rbenv][:install_prefix]}/rbenv"
 
-default[:ruby_build][:git_repository] = "git://github.com/sstephenson/ruby-build.git"
+default[:ruby_build][:git_repository] = "https://github.com/sstephenson/ruby-build.git"
 default[:ruby_build][:git_revision]   = "master"
 
-default[:rbenv_vars][:git_repository] = "git://github.com/sstephenson/rbenv-vars.git"
+default[:rbenv_vars][:git_repository] = "https://github.com/sstephenson/rbenv-vars.git"
 default[:rbenv_vars][:git_revision]   = "master"


### PR DESCRIPTION
Corporate firewalls enjoy blocking Git protocol access but most allow
for HTTPS access to GitHub.
