### PR TITLE
Options should be a kind_of String

### DIFF
--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -27,7 +27,7 @@ attribute :version,         :kind_of => String
 attribute :source,          :kind_of => String
 attribute :gem_binary,      :kind_of => String
 attribute :response_file,   :kind_of => String
-attribute :options,         :kind_of => Hash
+attribute :options,         :kind_of => String
 
 def initialize(*args)
   super


### PR DESCRIPTION
From https://github.com/opscode/chef/blob/master/lib/chef/provider/package/rubygems.rb

Line 369-71:
If you have a gem_binary specified, you cannot have options as a Hash.

Line 377-80
If you're using Omnibus, your options should be a String.

Also, there doesn't seem to be any example of how to use options as a hash so it's not clear how to do something like "--force".
