### PR TITLE
Adding in support for urls as patches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Attribute    | Description                                                 | Def
 ruby_version | the ruby version and patch level you wish to install        | name
 force        | install even if this version is already present (reinstall) | false
 global       | set this ruby version as the global version                 | false
+patch        | a url for `rbenv install --patch` to pull in                |
+
+Using the `patch` attribute requires that patchutils is installed, so that it can use filterdiff to remove parts of the patch (the Changelog which usually causes merge conflicts).
 
 ### Examples
 
@@ -105,6 +108,14 @@ global       | set this ruby version as the global version                 | fal
       ruby_version "1.9.3-p0"
       force true
     end
+
+##### Install Ruby 2.1.1 with a patch for ubuntu 14.04 support
+
+    rbenv_ruby "2.1.1" do
+      global true
+      patch "https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/45225/diff?format=diff"
+    end
+
 
 ## rbenv_gem
 

--- a/libraries/chef_mixin_rbenv.rb
+++ b/libraries/chef_mixin_rbenv.rb
@@ -44,7 +44,16 @@ class Chef
           },
           :timeout => 3600
         }
-        shell_out("#{rbenv_bin_path}/rbenv #{cmd}", Chef::Mixin::DeepMerge.deep_merge!(options, default_options))
+        if patch = options.delete(:patch)
+          Chef::Log.info("Patch found at: #{patch}")
+          unless filterdiff_installed?
+            Chef::Log.error("Cannot find filterdiff. Please install patchutils to be able to use patches.")
+            raise "Cannot find filterdiff. Please install patchutils to be able to use patches."
+          end
+          shell_out("curl -fsSL #{patch} | filterdiff -x ChangeLog | #{rbenv_bin_path}/rbenv #{cmd}", Chef::Mixin::DeepMerge.deep_merge!(options, default_options))
+        else
+          shell_out("#{rbenv_bin_path}/rbenv #{cmd}", Chef::Mixin::DeepMerge.deep_merge!(options, default_options))
+        end
       end
 
       def rbenv_installed?
@@ -54,6 +63,11 @@ class Chef
 
       def ruby_version_installed?(version)
         out = rbenv_command("prefix", :env => { 'RBENV_VERSION' => version })
+        out.exitstatus == 0
+      end
+
+      def filterdiff_installed?
+        out = shell_out("which filterdiff")
         out.exitstatus == 0
       end
 

--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -28,8 +28,9 @@ action :install do
     Chef::Log.info "rbenv_ruby[#{new_resource.name}] is building, this may take a while..."
 
     start_time = Time.now
-
-    out = rbenv_command("install #{new_resource.name}")
+    out = new_resource.patch ?
+      rbenv_command("install --patch #{new_resource.name}", patch: new_resource.patch) :
+      rbenv_command("install #{new_resource.name}")
 
     unless out.exitstatus == 0
       raise Chef::Exceptions::ShellCommandFailed, "\n" + out.format_for_exception

--- a/resources/ruby.rb
+++ b/resources/ruby.rb
@@ -24,6 +24,7 @@ actions :install
 attribute :ruby_version, :kind_of => String, :name_attribute => true
 attribute :force,        :default => false
 attribute :global,       :default => false
+attribute :patch,        :default => nil
 
 def initialize(*args)
   super


### PR DESCRIPTION
Firstly this requires patchutils to be installed so that we can use
filterdiff. I’m not entirely happy with this, but is a first cut of
this functionality so happy to have a discussion over it.

Allow the rbenv_ruby LWRP to support a patch variable, which is simply
a URL that rbenv install --patch will pull in. Written in a similar
style to here.
https://github.com/sstephenson/ruby-build/wiki#make-error-for-200-p247-and-lower-on-fedorared-hat

An example is:

```
rbenv_ruby "2.1.1" do
  global true
  patch "https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/45225/diff?format=diff"
end
```
