### PR TITLE
Ensure $HOME is correct before a ruby build (possibly from git.)

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -27,10 +27,15 @@ action :install do
   else
     Chef::Log.info "rbenv_ruby[#{new_resource.name}] is building, this may take a while..."
 
+    original_env_home = ENV['HOME']
+    ENV['HOME'] = home_directory_for_user(node[:rbenv][:user])
+
     start_time = Time.now
     out = new_resource.patch ?
       rbenv_command("install --patch #{new_resource.name}", patch: new_resource.patch) :
       rbenv_command("install #{new_resource.name}")
+
+    ENV['HOME'] = original_env_home
 
     unless out.exitstatus == 0
       raise Chef::Exceptions::ShellCommandFailed, "\n" + out.format_for_exception


### PR DESCRIPTION
This is a continuation of the work in db913928da8a389ff8edd98309dfb00ea3fa9fd8 which added a workaround for a git bug when using git to clone the rbenv install. But the bug is also present when a ruby build happens from a git source. This patch ensures that $HOME is temporarily changed to the home directory for `node[:rbenv][:user]` during the ruby build process.
