### PR TITLE
Handle ruby-build custom definition files gracefully.

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -22,7 +22,9 @@
 include Chef::Mixin::Rbenv
 
 action :install do
-  if !new_resource.force && ruby_version_installed?(new_resource.name)
+  ruby_name = ::File.basename(new_resource.name)
+
+  if !new_resource.force && ruby_version_installed?(ruby_name)
     Chef::Log.debug "rbenv_ruby[#{new_resource.name}] is already installed so skipping"
   else
     Chef::Log.info "rbenv_ruby[#{new_resource.name}] is building, this may take a while..."
@@ -45,16 +47,16 @@ action :install do
     }
 
     unless Chef::Platform.windows?
-      shell_out("chmod -R 0775 versions/#{new_resource.name}", chmod_options)
-      shell_out("find versions/#{new_resource.name} -type d -exec chmod +s {} \\;", chmod_options)
+      shell_out("chmod -R 0775 versions/#{ruby_name}", chmod_options)
+      shell_out("find versions/#{ruby_name} -type d -exec chmod +s {} \\;", chmod_options)
     end
 
     new_resource.updated_by_last_action(true)
   end
 
-  if new_resource.global && !rbenv_global_version?(new_resource.name)
-    Chef::Log.info "Setting #{new_resource.name} as the rbenv global version"
-    out = rbenv_command("global #{new_resource.name}")
+  if new_resource.global && !rbenv_global_version?(ruby_name)
+    Chef::Log.info "Setting #{ruby_name} as the rbenv global version"
+    out = rbenv_command("global #{ruby_name}")
     unless out.exitstatus == 0
       raise Chef::Exceptions::ShellCommandFailed, "\n" + out.format_for_exception
     end


### PR DESCRIPTION
ruby-build optionally accepts a path to a custom definition file in place of one of the built-in definition names. This patch fixes support for that use case by using the ruby name rather than the path when:
- Determining whether an install is needed.
- Setting global ruby versions.
- Setting file permissions.
