### PR TITLE
rbenv_gem's options should be a String

### DIFF
--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -27,7 +27,7 @@ attribute :version,         :kind_of => String
 attribute :source,          :kind_of => String
 attribute :gem_binary,      :kind_of => String
 attribute :response_file,   :kind_of => String
-attribute :options,         :kind_of => Hash
+attribute :options,         :kind_of => String
 
 def initialize(*args)
   super


### PR DESCRIPTION
rbenv_gem's options should be a String. When I passed a Hash, I got following error:

```
==> default: ArgumentError
==> default: -------------
==> default: options should be a string instead of a hash
==> default: in rbenv_gem[rake] from /tmp/vagrant-chef-3/chef-solo-1/cookbooks/gco/recipes/default.rb:25:in `from_file'
==> default:
==> default:
==> default: Cookbook Trace:
==> default: ---------------
==> default: /tmp/vagrant-chef-3/chef-solo-1/cookbooks/rbenv/libraries/provider_rbenv_rubygems.rb:64:in `initialize'
==> default:
==> default:
==> default: Resource Declaration:
==> default: ---------------------
==> default: # In /tmp/vagrant-chef-3/chef-solo-1/cookbooks/gco/recipes/default.rb
==> default:
==> default:  25: rbenv_gem "rake" do
==> default:  26:   ruby_version "2.1.2"
==> default:  27:   options force: true
==> default:  28: end
==> default:  29:
```
