### PR TITLE
Update gem.rb

### DIFF
--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -27,7 +27,7 @@ attribute :version,         :kind_of => String
 attribute :source,          :kind_of => String
 attribute :gem_binary,      :kind_of => String
 attribute :response_file,   :kind_of => String
-attribute :options,         :kind_of => Hash
+attribute :options,         :kind_of => [String, Hash]
 
 def initialize(*args)
   super


### PR DESCRIPTION
Added string as an accepted input type for the "options" attribute.

I did this when trying to pass options for installing nokogiri and couldnt understand how to properly follow the installers instructions on error:

use: gem install nokogiri -- --use-system-libraries

With the change in this pull request the following works perfectly:

rbenv_gem "nokogiri" do
  ruby_version "1.9.3-p545"
  options '-- --use-system-libraries'
end
