### PR TITLE
create hotfix for smartos and update to set config_option as resource attribute

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ recipe "rbenv::ruby_build", "Installs and configures ruby_build"
 recipe "rbenv::ohai_plugin", "Installs an rbenv Ohai plugin to populate automatic_attrs about rbenv and ruby_build"
 recipe "rbenv::rbenv_vars", "Installs an rbenv plugin rbenv-vars that lets you set global and project-specific environment variables before spawning Ruby processes"
 
-%w{ centos redhat fedora ubuntu debian amazon oracle}.each do |os|
+%w{ centos redhat fedora ubuntu debian amazon oracle smartos}.each do |os|
   supports os
 end
 

--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -28,9 +28,16 @@ action :install do
     Chef::Log.info "rbenv_ruby[#{new_resource.name}] is building, this may take a while..."
 
     start_time = Time.now
+    ruby_configure_opts = {}
+    unless new_resource.config_opts.empty?
+      ruby_configure_opts[:env] = {
+        "RUBY_CONFIGURE_OPTS" => new_resource.config_opts.join(' ')
+      }
+    end
+
     out = new_resource.patch ?
-      rbenv_command("install --patch #{new_resource.name}", patch: new_resource.patch) :
-      rbenv_command("install #{new_resource.name}")
+      rbenv_command("install --patch #{new_resource.name}", {patch: new_resource.patch}.merge(ruby_configure_opts)) :
+      rbenv_command("install #{new_resource.name}", ruby_configure_opts)
 
     unless out.exitstatus == 0
       raise Chef::Exceptions::ShellCommandFailed, "\n" + out.format_for_exception

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -106,6 +106,8 @@ with_home_for_user(node[:rbenv][:user]) do
 
 end
 
+include_recipe "rbenv::hotfix_smartos" if node[:platform] == 'smartos'
+
 template "/etc/profile.d/rbenv.sh" do
   source "rbenv.sh.erb"
   mode "0644"

--- a/recipes/hotfix_smartos.rb
+++ b/recipes/hotfix_smartos.rb
@@ -1,10 +1,10 @@
 #
 # Cookbook Name:: rbenv
-# Resource:: ruby
+# Recipe:: hotfix_smartos
 #
-# Author:: Jamie Winsor (<jamie@vialstudios.com>)
+# Author:: SAWANOBORI Yukihiko (<sawanoboriyu@higanworks.com>)
 #
-# Copyright 2011-2012, Riot Games
+# Copyright 2011-2014, HiganWorks LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,15 +19,14 @@
 # limitations under the License.
 #
 
-actions :install
+directory '/etc/profile.d' do
+  action :create
+end
 
-attribute :ruby_version, :kind_of => String, :name_attribute => true
-attribute :force,        :default => false
-attribute :global,       :default => false
-attribute :patch,        :default => nil
-attribute :config_opts,  :kind_of => Array, :default => []
-
-def initialize(*args)
-  super
-  @action = :install
+ruby_block 'edit_profile_for_smartos' do
+  block do
+    _file = Chef::Util::FileEdit.new('/etc/profile')
+    _file.insert_line_if_no_match('Appends by rbenv cookbook', "## Appends by rbenv cookbook\nif [ -d /etc/profile.d ]; then\n  for i in /etc/profile.d/*.sh; do\n    if [ -r $i ]; then\n      . $i\n    fi\n  done\n  unset i\nfi\n")
+    _file.write_file
+  end
 end


### PR DESCRIPTION
Hi,
I wrote 2 updates.
- FIx for smartos
  - Joyent SmartOS doesn't have `/etc/profile.d` directory. I would like to create it.
- Add  config_opts resource attribute to `rbenv_ruby`.
  - When I build 2.0.0 or newer on the smartos, I often need some  Environment variables from `RUBY_CONFIGURE_OPTS` such as '--disable-dtrace'.
