### PR TITLE
Update rbenv_gem to allow for local .gem installs

### DIFF
--- a/libraries/provider_rbenv_rubygems.rb
+++ b/libraries/provider_rbenv_rubygems.rb
@@ -81,7 +81,11 @@ class Chef
         end
 
         def install_via_gem_command(name, version = nil)
-          src            = @new_resource.source && "  --source=#{@new_resource.source} --source=http://rubygems.org"
+          if @new_resource.source =~ /\.gem$/i
+            name = @new_resource.source
+          else
+            src = @new_resource.source && " --source=#{@new_resource.source} --source=https://rubygems.org"
+          end
           version_option = (version.nil? || version.empty?) ? "" : " -v \"#{version}\""
 
           shell_out!(


### PR DESCRIPTION
I believe this is the change your requested in #47.

A new code path is introduced where we detect a :source option that ends
with ".gem" and don't include any "--source" arguments in our call to
the gem command. This has the intended behavior of installing the .gem
file passed as source.

For example:

```
rbenv_gem 'god' do
  ruby_version '2.0.0-p353'
  source '/tmp/god-0.13.4.gem'
end
```

Also took the opportunity to update the --source line from http:// to https://
