### PR TITLE
Use lazy evaluation for the derived attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,8 +26,8 @@ default[:rbenv][:group_users]    = Array.new
 default[:rbenv][:git_repository] = "https://github.com/sstephenson/rbenv.git"
 default[:rbenv][:git_revision]   = "master"
 default[:rbenv][:install_prefix] = "/opt"
-default[:rbenv][:root_path]      = "#{node[:rbenv][:install_prefix]}/rbenv"
-default[:rbenv][:user_home]      = "/home/#{node[:rbenv][:user]}"
+default[:rbenv][:root_path]      = "%{node[:rbenv][:install_prefix]}/rbenv"
+default[:rbenv][:user_home]      = "/home/%{node[:rbenv][:user]}"
 
 default[:ruby_build][:git_repository] = "https://github.com/sstephenson/ruby-build.git"
 default[:ruby_build][:git_revision]   = "master"


### PR DESCRIPTION
Use lazy evaluation for the derived attributes to delay the string interpolation until later.
With this user can override only one attribute without need for overriding all other attributes that use main one.

For example (before PR):

```
node.default[:rbenv][:install_prefix] = "/usr/local"
```

by overriding `install_prefix` you would not override `default[:rbenv][:root_path]` because it's interpolated before attribute from wrapper cookbook existed.

More info about this problem you can [find here](https://coderanger.net/derived-attributes/) (tnx to @coderanger).
