### PR TITLE
support verbose mode in rbenv_ruby resource

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -29,9 +29,14 @@ action :install do
     Chef::Log.info "#{resource_descriptor} is building, this may take a while..."
 
     start_time = Time.now
+    command = 'install'
+    command << ' --patch' if new_resource.patch
+    command << " #{new_resource.ruby_version}" if new_resource.verbose
+    command << ' --verbose'
+
     out = new_resource.patch ?
-      rbenv_command("install --patch #{new_resource.ruby_version}", patch: new_resource.patch) :
-      rbenv_command("install #{new_resource.ruby_version}")
+      rbenv_command(command, patch: new_resource.patch) :
+      rbenv_command(command)
 
     unless out.exitstatus == 0
       raise Chef::Exceptions::ShellCommandFailed, "\n" + out.format_for_exception

--- a/resources/ruby.rb
+++ b/resources/ruby.rb
@@ -26,6 +26,7 @@ attribute :ruby_version, :kind_of => String
 attribute :force,        :default => false
 attribute :global,       :default => false
 attribute :patch,        :default => nil
+attribute :verbose,      :default => false
 
 def initialize(*args)
   super


### PR DESCRIPTION
this can be useful for debug and can solve timeout issues in ci when tests are stopped, because there is no output for a long time.  
