### PR TITLE
sh/dash doesnt support `source`

### DIFF
--- a/templates/default/rbenv.sh.erb
+++ b/templates/default/rbenv.sh.erb
@@ -8,6 +8,8 @@ case $SHELL in
 */bash)
   source $RBENV_ROOT/completions/rbenv.bash
   ;;
+*/sh)
+  ;;
 *)
   source $RBENV_ROOT/completions/rbenv.bash
   ;;


### PR DESCRIPTION
$ source
-sh: 4: source: not found
