### PR TITLE
Add CONFIGURE_OPTS to customize ruby installation. E.g.: --enable-dtrace

### DIFF
--- a/libraries/chef_mixin_rbenv.rb
+++ b/libraries/chef_mixin_rbenv.rb
@@ -44,15 +44,20 @@ class Chef
           },
           :timeout => 3600
         }
+
+        if flags = options.delete(:flags)
+          configure_opts = "CONFIGURE_OPTS='#{flags}'"
+        end
+
         if patch = options.delete(:patch)
           Chef::Log.info("Patch found at: #{patch}")
           unless filterdiff_installed?
             Chef::Log.error("Cannot find filterdiff. Please install patchutils to be able to use patches.")
             raise "Cannot find filterdiff. Please install patchutils to be able to use patches."
           end
-          shell_out("curl -fsSL #{patch} | filterdiff -x ChangeLog | #{rbenv_bin_path}/rbenv #{cmd}", Chef::Mixin::DeepMerge.deep_merge!(options, default_options))
+          shell_out("curl -fsSL #{patch} | filterdiff -x ChangeLog | #{configure_opts} #{rbenv_bin_path}/rbenv #{cmd}", Chef::Mixin::DeepMerge.deep_merge!(options, default_options))
         else
-          shell_out("#{rbenv_bin_path}/rbenv #{cmd}", Chef::Mixin::DeepMerge.deep_merge!(options, default_options))
+          shell_out("#{configure_opts} #{rbenv_bin_path}/rbenv #{cmd}", Chef::Mixin::DeepMerge.deep_merge!(options, default_options))
         end
       end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       "Riot Games"
 maintainer_email "jamie@vialstudios.com"
 license          "Apache 2.0"
 description      "Installs and configures rbenv"
-version          "1.7.1"
+version          "1.7.2"
 
 recipe "rbenv", "Installs and configures rbenv"
 recipe "rbenv::ruby_build", "Installs and configures ruby_build"

--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -31,7 +31,7 @@ action :install do
     start_time = Time.now
     out = new_resource.patch ?
       rbenv_command("install --patch #{new_resource.ruby_version}", patch: new_resource.patch) :
-      rbenv_command("install #{new_resource.ruby_version}")
+      rbenv_command("install #{new_resource.ruby_version}", flags: new_resource.flags)
 
     unless out.exitstatus == 0
       raise Chef::Exceptions::ShellCommandFailed, "\n" + out.format_for_exception

--- a/resources/ruby.rb
+++ b/resources/ruby.rb
@@ -26,6 +26,7 @@ attribute :ruby_version, :kind_of => String
 attribute :force,        :default => false
 attribute :global,       :default => false
 attribute :patch,        :default => nil
+attribute :flags,        :kind_of => String
 
 def initialize(*args)
   super


### PR DESCRIPTION
Add CONFIGURE_OPTS to customize ruby installation. E.g.: --enable-dtrace. This is needed for profiling, tracing tools like systemtap, dtrace.
