### PR TITLE
rbenv_ruby: Use ruby_version as name attribute

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -53,7 +53,7 @@ action :install do
     new_resource.updated_by_last_action(true)
   end
 
-  if new_resource.global && !rbenv_global_version?(new_resource.name)
+  if new_resource.global && !rbenv_global_version?(new_resource.ruby_version)
     Chef::Log.info "Setting #{resource_descriptor} as the rbenv global version"
     out = rbenv_command("global #{new_resource.ruby_version}")
     unless out.exitstatus == 0

--- a/resources/ruby.rb
+++ b/resources/ruby.rb
@@ -21,8 +21,7 @@
 
 actions :install
 
-attribute :name, :kind_of => String
-attribute :ruby_version, :kind_of => String
+attribute :ruby_version, :kind_of => String, :name_attribute => true
 attribute :force,        :default => false
 attribute :global,       :default => false
 attribute :patch,        :default => nil
@@ -30,5 +29,4 @@ attribute :patch,        :default => nil
 def initialize(*args)
   super
   @action = :install
-  @ruby_version ||= @name
 end


### PR DESCRIPTION
The previous way would cause weirdness and sometimes overwrite
the ruby_version with the :name.

This should fix this case:

```
rbenv_ruby 'default ruby' do
  ruby_version '2.1.2'
  global true
end
```

Which raised an error when it tried to do `rbenv install default ruby`
