### PR TITLE
Unset TMPDIR on Darwin (Mac OS X)

### DIFF
--- a/libraries/chef_mixin_rbenv.rb
+++ b/libraries/chef_mixin_rbenv.rb
@@ -52,7 +52,11 @@ class Chef
           end
           shell_out("curl -fsSL #{patch} | filterdiff -x ChangeLog | #{rbenv_bin_path}/rbenv #{cmd}", Chef::Mixin::DeepMerge.deep_merge!(options, default_options))
         else
-          shell_out("#{rbenv_bin_path}/rbenv #{cmd}", Chef::Mixin::DeepMerge.deep_merge!(options, default_options))
+          if RUBY_PLATFORM =~ /darwin/
+            shell_out("unset TMPDIR; #{rbenv_bin_path}/rbenv #{cmd}", Chef::Mixin::DeepMerge.deep_merge!(options, default_options))
+          else
+            shell_out("#{rbenv_bin_path}/rbenv #{cmd}", Chef::Mixin::DeepMerge.deep_merge!(options, default_options))
+          end
         end
       end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ recipe "rbenv::ruby_build", "Installs and configures ruby_build"
 recipe "rbenv::ohai_plugin", "Installs an rbenv Ohai plugin to populate automatic_attrs about rbenv and ruby_build"
 recipe "rbenv::rbenv_vars", "Installs an rbenv plugin rbenv-vars that lets you set global and project-specific environment variables before spawning Ruby processes"
 
-%w{ centos redhat fedora ubuntu debian amazon oracle}.each do |os|
+%w{ centos redhat fedora ubuntu debian amazon oracle mac_os_x }.each do |os|
   supports os
 end
 


### PR DESCRIPTION
Between Chef, Ruby, and the rbenv cookbook, there is a edge case that
manifests on OS X when you set an rbenv user.

It is caused by the fact that the rbenv command is run under the context
of the rbenv user, but still has some of the shell environments from the
initiating user (like TMPDIR), which means that rbenv can't write to the
temporary directory, so we can't let the rbenv commands rely on that
environment variable.

This simply ensures that we use a standard temp directory and adds
"mac_os_x" to the supported operating systems.

Note: On OS X every single user has their own default temporary directory,
that has permissions very restrictive permissions tied to that user.
