### PR TITLE
Check for successful ruby install under rbenv.

### DIFF
--- a/libraries/chef_mixin_rbenv.rb
+++ b/libraries/chef_mixin_rbenv.rb
@@ -57,7 +57,7 @@ class Chef
       end
 
       def rbenv_installed?
-        out = shell_out("ls #{rbenv_bin_path}/rbenv")
+        out = shell_out("ls #{rbenv_bin_path}/rbenv/versions/*/bin/ruby")
         out.exitstatus == 0
       end
 

--- a/libraries/chef_mixin_rbenv.rb
+++ b/libraries/chef_mixin_rbenv.rb
@@ -57,7 +57,7 @@ class Chef
       end
 
       def rbenv_installed?
-        out = shell_out("ls #{rbenv_bin_path}/rbenv/versions/*/bin/ruby")
+        out = shell_out("#{rbenv_bin_path}/rbenv/versions/#{RBENV_VERSION}/bin/ruby -v")
         out.exitstatus == 0
       end
 


### PR DESCRIPTION
If the URL provided for the install is not available (for example, flaky internet, behind a corporate firewall), the first invocation of this cookbook creates an rbenv directory, and then fails to :sync. Subsequent invocations of the cookbook see that extant directory, and assume that rbenv has been installed, without needing to :sync, and fail. This edit looks for at least one rbenv/versions/*/bin/ruby file.
